### PR TITLE
Add --cuckoo-cpu-assist-min to miner config gen

### DIFF
--- a/Miners/zjazz-nvidia-12f.ps1
+++ b/Miners/zjazz-nvidia-12f.ps1
@@ -15,9 +15,16 @@ $Cfg = [BaseConfig]::ReadOrCreate([IO.Path]::Combine($PSScriptRoot, $Name + [Bas
 	ExtraArgs = $null
 	Algorithms = @(
 		[AlgoInfoEx]@{ Enabled = $true; Algorithm = "bitcash" }
-		[AlgoInfoEx]@{ Enabled = $true; Algorithm = "bitcash"; ExtraArgs="--cuckoo-intensity 16" } # 3Gb
-		[AlgoInfoEx]@{ Enabled = $true; Algorithm = "bitcash"; ExtraArgs="--cuckoo-intensity 18" } # 4Gb
-		[AlgoInfoEx]@{ Enabled = $true; Algorithm = "bitcash"; ExtraArgs="--cuckoo-intensity 22" } # 8Gb
+		[AlgoInfoEx]@{ Enabled = $true; Algorithm = "bitcash"; ExtraArgs="--cuckoo-cpu-assist-min" }
+		[AlgoInfoEx]@{ Enabled = $false; Algorithm = "bitcash"; ExtraArgs="--cuckoo-intensity 16" } # 3Gb
+		[AlgoInfoEx]@{ Enabled = $true; Algorithm = "bitcash"; ExtraArgs="--cuckoo-intensity 16 --cuckoo-cpu-assist-min" } # 3Gb
+		[AlgoInfoEx]@{ Enabled = $false; Algorithm = "bitcash"; ExtraArgs="--cuckoo-intensity 18" } # 4Gb
+		[AlgoInfoEx]@{ Enabled = $true; Algorithm = "bitcash"; ExtraArgs="--cuckoo-intensity 18 --cuckoo-cpu-assist-min" } # 4Gb
+		[AlgoInfoEx]@{ Enabled = $false; Algorithm = "bitcash"; ExtraArgs="--cuckoo-intensity 22" } # 8Gb lowmem
+		[AlgoInfoEx]@{ Enabled = $true; Algorithm = "bitcash"; ExtraArgs="--cuckoo-intensity 22 --cuckoo-cpu-assist-min" } # 8Gb lowmem
+		[AlgoInfoEx]@{ Enabled = $false; Algorithm = "bitcash"; ExtraArgs="-g 2 --cuckoo-intensity 22" } # 8Gb
+		[AlgoInfoEx]@{ Enabled = $true; Algorithm = "bitcash"; ExtraArgs="-g 2 --cuckoo-intensity 22 --cuckoo-cpu-assist-min" } # 8Gb
+		[AlgoInfoEx]@{ Enabled = $false; Algorithm = "bitcash"; ExtraArgs="-g 2" } # 11Gb
 		[AlgoInfoEx]@{ Enabled = $false; Algorithm = "x22i" }
 )})
 


### PR DESCRIPTION
This added parameter runs a bit faster after you let 3+ hours of Bitcash mining happen to even out stats, please try